### PR TITLE
No dups

### DIFF
--- a/rss_feed_parser.py
+++ b/rss_feed_parser.py
@@ -35,11 +35,16 @@ class RssFeedParser(object):
                     etag_file.write(feed.etag)
             self.etag = feed.etag
         articles = []
-        already_seen = []
         for entry in feed.entries:
             link = entry.link
             if link in self._already_seen:
-                raise Exception('The link "{}" has already been crawled'.format(link))
+                raise Exception(
+                    '''ERR_DUP_LINK,{link},{etag},{feed}'''.format(
+                        link,
+                        self.etag,
+                        self.rss_url
+                    )
+                )
             self._already_seen.add(link)
             articles.append(
                 RssArticle(


### PR DESCRIPTION
add a set to enforce with an exception not crawling the same link twice. this should log the etag and rss feed, so we can try to reproduce the bug.
