### PR TITLE
Handle duplicate articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,17 @@
 # Ignore Python compiled files.
 *.pyc
+
+# application state
 *.etag
+
+# virtualenv
 venv
 ENV
+
+# logging
 nohup.out
+*.log
+
+# IPython debugging
+*.ipynb
+.ipynb_checkpoints

--- a/article.py
+++ b/article.py
@@ -36,12 +36,11 @@ class Article(object):
         self.meta_lang = None
         self.pub_date = None
         self.html = None
-
-        self.parsed = False
+        self._parsed = False
         self._parser = parser or _getParserForUrl(url)
 
     def download_and_parse(self):
-        if self.parsed:
+        if self._parsed:
             raise Exception('This article ({}) has already been parsed.'.format(self.url))
 
         article = newspaper.build_article(self.url)

--- a/crawlers.py
+++ b/crawlers.py
@@ -5,6 +5,7 @@ from downloaders import *
 import multiprocessing
 import sys
 import random
+import logging
 
 class ModularCrawler(object):
     def __init__(self, args):
@@ -171,10 +172,15 @@ class MultipleRSSMongoCrawler(object):
         self._rss_parser = MultipleRSSFeedParser(config['feeds'])
         mongo_kw_args = config['mongo_params']
         self._article_writer = MongoWriter(**mongo_kw_args)
+        self._logger = logging.getLogger('retina-crawler')
 
     def crawl(self):
         for article in self._rss_parser.get_new_articles():
-            article.download_and_parse()
+            try:
+                article.download_and_parse()
+            except Exception, e:
+                self._logger.exception(e)
+                continue
             self._article_writer.write(article)            
         return True
 

--- a/main.py
+++ b/main.py
@@ -81,13 +81,15 @@ def main():
 
     while True: #TODO(): try-except properly everywhere / do a service
         try:
-            start = int(time.time())
-            while crawler.crawl():
+            continue_crawling = True
+            while continue_crawling:
+                start = time.time()
+                continue_crawling = crawler.crawl()
                 logger.info(str(time.ctime()) + ":Finished a round of crawling.")
                 # Track how long crawling took and make sure it doesn't run more frequently than once per minute.
-                end = int(time.time())
-                if end - start < 60:
-                    time.sleep(1)
+                end = time.time()
+                if end - start < 60.0:
+                    time.sleep(15.0)
                 else:
                     continue
         # Handle early termination (Ctrl+C)
@@ -97,7 +99,7 @@ def main():
         except Exception, e:
             # This code should not be called and is considered a bug if it does.
             logger.exception(e)
-            time.sleep(4) #TODO():
+            time.sleep(5.0) #TODO():
 
 if __name__ == "__main__":
     main()

--- a/rss_feed_parser.py
+++ b/rss_feed_parser.py
@@ -1,7 +1,8 @@
 import feedparser
 import urlparse
 from article import RssArticle, Article
-from time import mktime
+import time
+import logging
 from datetime import datetime
 
 class RssFeedParser(object):
@@ -9,7 +10,9 @@ class RssFeedParser(object):
         self.etag = None
         self.rss_url = rss_url
         self.etag_filename = self._get_filename(rss_url)
-        self._already_seen = set([])
+        self.feed_update_count = 0
+        self._previous_entries = {}
+
         try:
             with open(self.etag_filename) as old_etag_file:
                 etag = old_etag_file.read()
@@ -27,34 +30,75 @@ class RssFeedParser(object):
             path=path_formatted
         )
 
+    def _save_etag(self, etag):
+        self.etag = etag
+        with open(self.etag_filename, 'w+') as etag_file:
+            etag_file.write(etag)
+
+    def _deduplicate_entries(self, rss_entries):
+        return max(rss_entries, key=lambda entry: entry.published_parsed)
+
+    def _unique_entries_by_link(self, rss_entries):
+        rss_entries_by_link = {}
+
+        for entry in rss_entries:
+            if entry.link in rss_entries_by_link:
+                rss_entries_by_link[entry.link].append(entry)
+            else:
+                rss_entries_by_link[entry.link] = [entry]
+
+        for link, rss_entries in rss_entries_by_link.iteritems():
+            selected_entry = self._deduplicate_entries(rss_entries)
+            yield link, selected_entry
+
+    def _filter_new(self, entries):
+        for link, entry in entries:
+            if link not in self._previous_entries:
+                yield link, entry
+                self._previous_entries[link] = set([entry.published_parsed])
+            elif entry.published_parsed not in self._previous_entries[link]:
+                yield link, entry
+                self._previous_entries[link].add(entry.published_parsed)
+
     def get_new_articles(self):
-        feed = feedparser.parse(self.rss_url, etag = self.etag)
-        if 'etag' in feed:
-            if feed.etag != self.etag:
-                with open(self.etag_filename, 'w+') as etag_file:
-                    etag_file.write(feed.etag)
-            self.etag = feed.etag
-        articles = []
-        for entry in feed.entries:
-            link = entry.link
-            if link in self._already_seen:
-                raise Exception(
-                    '''ERR_DUP_LINK,{link},{etag},{feed}'''.format(
-                        link=link,
-                        etag=self.etag,
-                        feed=self.rss_url
-                    )
-                )
-            self._already_seen.add(link)
-            articles.append(
+        resp = feedparser.parse(self.rss_url, etag = self.etag)
+        
+        if resp.status == 304: # Not modified
+            if 'etag' in resp:
+                raise Exception('ERR_NO_MOD_ETAG,Updated etag should not happen when the resource was not modified.')
+            return []
+
+        if 'etag' not in resp:
+            return []
+
+        if self.etag == resp.etag:
+            raise Exception('ERR_MOD_ETAG_NOT_MOD,resource modified, but etag not modified.')
+
+        self._save_etag(resp.etag)
+        self.feed_update_count += 1
+
+        new_articles = []
+        for link, entry in self._filter_new(self._unique_entries_by_link(resp.entries)):
+            article = \
                 RssArticle(
-                    entry.link,
-                    datetime.fromtimestamp(mktime(entry.published_parsed)),
+                    link,
+                    datetime.fromtimestamp(time.mktime(entry.published_parsed)),
                     entry.title,
                     entry.summary
                 )
+            new_articles.append(article)
+
+        logging.info('{_type},{time},{feed},{update_count},{num_entries},{new_entries}'.format(
+                _type='RSS_UPDATE',
+                time=time.time(),
+                feed=self.rss_url,
+                update_count=self.feed_update_count,
+                num_entries=len(resp.entries),
+                new_entries=len(new_articles)
             )
-        return articles
+        )
+
+        return new_articles
 
 class MultipleRSSFeedParser(object):
     def __init__(self, feeds):

--- a/writers.py
+++ b/writers.py
@@ -56,17 +56,48 @@ class MongoWriter():
         article -- An article!
         """
         db = self.m.big_data
-        article_doc = article.to_dict()
-        article_doc['v'] = '0.0.5'
-        html = article_doc['html']
-        del article_doc['html']
+        html = article.html
         html_id = ObjectId()
-        article_doc['html_id'] = html_id
+
+        article_doc_updates = {
+            'authors' : article.authors,
+            'categories' : article.categories,
+            'images' : article.images,
+            'keywords' : article.keywords,
+            'location' : article.location,
+            'meta_favicon' : article.meta_favicon,
+            'meta_lang' : article.meta_lang,
+            'recent_download_date' : article.download_date,
+            'recent_pub_date' : article.pub_date,
+            'source_domain' : article.source_domain,
+            'suggested_articles' : article.suggested_articles,
+            'summary' : article.summary,
+            'text' : article.text,
+            'title' : article.title,
+            'url' : article.url,
+            'v' : '0.0.6'
+        }
+
+        article_doc_history = {
+            'history' : {
+                'download_date' : article.download_date,
+                'html_id' : html_id,
+                'pub_date' :  article.pub_date
+            }
+        }
 
         html_doc = {
             '_id' : html_id,
             'html' : html
         }
 
-        db.articles.insert(article_doc)
+        db.articles.update(
+            {'url' : article.url},
+            {
+                '$set' : article_doc_updates,
+                '$push' : article_doc_history,
+                '$inc' : {'history_len' : 1}
+            },
+            upsert=True
+        )
         db.html.insert(html_doc)


### PR DESCRIPTION
Every time an article is updated in CNN, CNN publishes an RSS entry for each previous version of the article. This caused us to insert many duplicate entries into our database.This diff should fix our duplication problems. 

The first problem is an RSS feed duplicates articles by posting an entry for each update of an article. This fix to RSSFeedParser should handle this better.

The second problem is making sure we don't insert new entries for URLs we have already seen in a previous crawl. Now, in MongoDB if we receive an updated article that already exists in our database (whose URL we've already crawled), we update a history of the article instead of creating a new one. This way, all articles with the same URL only get 1 entry in the database.

This diff will change slightly the API between crawler and clusterer. @iRapha @mgruchacz you will want to look at recent_download_date and recent_pub_date instead of download_date and pub_date, to take into account that we can have several versions of the same article.
